### PR TITLE
suggestion to remove REQUEST_INSTALL_PACKAGES

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,6 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.fileOpener2.provider" android:exported="false" android:grantUriPermissions="true">


### PR DESCRIPTION
We've had an app review rejected from Google Play reviewer because of REQUEST_INSTALL_PACKAGES being "too broad"

Evil apps will attempt to masquerade their real behaviour and install 3rd party apks, like online gambling or casino games. This is a well reported thing by store security researchers.

I suggest the permission to be removed by default to prevent possible app review rejections.